### PR TITLE
Bump activesupport version to 5.2 or later

### DIFF
--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'net-http-persistent'
   s.add_runtime_dependency 'net-http2', '~> 0.18', '>= 0.18.3'
   s.add_runtime_dependency 'jwt', '>= 1.5.6'
-  s.add_runtime_dependency 'activesupport', '>= 5.0'
+  s.add_runtime_dependency 'activesupport', '>= 5.2'
   s.add_runtime_dependency 'thor', ['>= 0.18.1', '< 2.0']
   s.add_runtime_dependency 'railties'
   s.add_runtime_dependency 'rainbow'


### PR DESCRIPTION
According [0dbf80bbd0fe6aa5a82d29734866f4fd96ce109c](https://github.com/rpush/rpush/commit/0dbf80bbd0fe6aa5a82d29734866f4fd96ce109c), rpush don't tested with old rails. So, just clarify this is `gemspec`. 